### PR TITLE
Change the endpoints so they are easier to reverse proxy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,4 @@ tab_width = 2
 [*.java]
 indent_size = 4
 tab_width = 4
+continuation_indent_size = 8

--- a/webservice/src/main/java/com/vary/tenantsecrets/tenantsecrets/SecretsRestController.java
+++ b/webservice/src/main/java/com/vary/tenantsecrets/tenantsecrets/SecretsRestController.java
@@ -1,31 +1,38 @@
 package com.vary.tenantsecrets.tenantsecrets;
 
+import java.lang.invoke.MethodHandles;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/secrets")
+@RequestMapping("/secrets/api")
 public class SecretsRestController {
 
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-	private final SecretsService secretsService;
+    private final SecretsService secretsService;
 
-	@Autowired
-	public SecretsRestController(SecretsService secretsService) {
-		this.secretsService = secretsService;
-	}
+    @Autowired
+    public SecretsRestController(SecretsService secretsService) {
+        this.secretsService = secretsService;
+    }
 
-	@PostMapping("/{tenantId}")
-	public ResponseEntity<String> encrypt(@PathVariable("tenantId") String tenantId,
-										 @RequestBody String plainText) {
-		try {
-			String secret = secretsService.encrypt(plainText, tenantId);
-			return ResponseEntity.status(HttpStatus.CREATED).body(secret);
-		} catch (Exception e) {
-			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error generating secret.");
-		}
-	}
+    @PostMapping("/{tenantId}")
+    public ResponseEntity<String> encrypt(@PathVariable("tenantId") String tenantId,
+            @RequestBody String plainText) {
+        try {
+            String secret = secretsService.encrypt(plainText, tenantId);
+            return ResponseEntity.status(HttpStatus.CREATED).body(secret);
+        }
+        catch (Exception e) {
+            LOG.error("Error encrypting secret in REST API request", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error generating secret.");
+        }
+    }
 
 }

--- a/webservice/src/main/java/com/vary/tenantsecrets/tenantsecrets/SecretsUiController.java
+++ b/webservice/src/main/java/com/vary/tenantsecrets/tenantsecrets/SecretsUiController.java
@@ -1,5 +1,7 @@
 package com.vary.tenantsecrets.tenantsecrets;
 
+import java.lang.invoke.MethodHandles;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +21,7 @@ import javax.validation.constraints.NotEmpty;
 @RequestMapping("/secrets")
 public class SecretsUiController {
 
-	private static final Logger LOG = LoggerFactory.getLogger(SecretsUiController.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	private static final String SECRETS_FORM = "secretsForm";
 

--- a/webservice/src/test/java/com/vary/tenantsecrets/tenantsecrets/TenantsecretsApplicationTests.java
+++ b/webservice/src/test/java/com/vary/tenantsecrets/tenantsecrets/TenantsecretsApplicationTests.java
@@ -1,36 +1,45 @@
 package com.vary.tenantsecrets.tenantsecrets;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ContextConfiguration(
-		initializers = PropertyOverrideContextInitializer.class,
-		classes = TenantsecretsApplication.class)
+        initializers = PropertyOverrideContextInitializer.class,
+        classes = TenantsecretsApplication.class)
 class TenantsecretsApplicationTests {
 
-	@LocalServerPort
-	private int port;
+    @LocalServerPort
+    private int port;
 
-	@Autowired
-	private TestRestTemplate restTemplate;
+    @Autowired
+    private TestRestTemplate restTemplate;
 
-	@Test
-	void shouldEncrypt() {
-		ResponseEntity<String> response = restTemplate.postForEntity(
-				"http://localhost:" + port + "/api/secrets/my_group", "my secret", String.class);
+    @Test
+    void shouldEncrypt() {
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/secrets/api/my_group", "my secret", String.class);
 
-		assertEquals(201, response.getStatusCode().value());
-		assertTrue(response.getBody().startsWith("AES:"));
-	}
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).startsWith("AES:");
+    }
+
+    @Test
+    void shouldLoadUi() {
+        ResponseEntity<String> response = restTemplate.getForEntity(
+                "http://localhost:" + port + "/secrets", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("<form");
+    }
 
 }


### PR DESCRIPTION
Old:

    GUI: http://localhost:1717/secrets
    REST: http://localhost:1717/api/secrets

New:

    GUI: http://localhost:1717/secrets
    REST: http://localhost:1717/secrets/api

This way you can have an NGINX configuration that proxies "/secrets" to "/secrets". With the old config, either you needed two location definitions, or an extra prefix in the path requested by the client.